### PR TITLE
refactor .py code for separation of concerns & OO abstractions

### DIFF
--- a/rids/config.py
+++ b/rids/config.py
@@ -1,0 +1,36 @@
+# Copyright 2022 Jigsaw Operations LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Configuration parsing and validataion.
+
+The config format may change, certainly its contents will.  This is where
+type-checking and consistency checks go.
+"""
+
+import json
+
+
+def parse_file(file_path):
+  """Parse the configuration defined at the indicated path."""
+  # TODO validation checks on config values, schema isn't yet defined
+  with open(file_path) as f:
+    return json.load(f)
+
+
+def parse_string(config_str):
+  """Parse a configuration from a utf8 str-like representation."""
+  # TODO: validation checks in common with file-based parsing.
+  # Simple implementation for now.
+  return json.loads(f)

--- a/rids/iocs/bad_ip_list.py
+++ b/rids/iocs/bad_ip_list.py
@@ -1,0 +1,52 @@
+# Copyright 2022 Jigsaw Operations LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IOC feed parser for lists of compromised host IPs (newline separated)."""
+
+
+from datetime import datetime
+import ipaddress
+
+from rids import rules
+
+
+class FeedParser:
+  """Parses newline-separated list of IP addresses into a RuleSet."""
+  def __init__(self, config):
+    self.source_name = config.get('name', 'UNKNOWN')
+    self.msg = config.get('msg', 'contact with a potentially compromised host')
+
+  def ParseFile(self, ioc_filedata):
+    timestamp = str(datetime.now())
+    ruleset = rules.RuleSet()
+    for line in ioc_filedata.readlines():
+      line = line.decode('utf-8').strip()
+      if not line or line[0] == '#':
+        # skip empty lines and comments
+        continue
+      try:
+        bad_ip = ipaddress.ip_address(line)
+      except ValueError:
+        # Do nothing with badly-formatted addresses in these files.
+        continue
+
+      rule = rules.Rule(
+          msg=self.msg,
+          source=self.source_name,
+          fetched=timestamp,
+          matches_ip=bad_ip,
+      )
+      ruleset.AddRule(rule)
+
+    return ruleset

--- a/rids/iocs/iocs.py
+++ b/rids/iocs/iocs.py
@@ -1,0 +1,48 @@
+# Copyright 2022 Jigsaw Operations LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Combined IOC feed parser interface for the different formats of IOCs."""
+
+
+import urllib.request
+
+from rids.iocs import bad_ip_list
+
+
+_PARSERS = {
+  "BAD_IP_LIST": bad_ip_list.FeedParser,
+}
+
+
+def fetch_and_parse_ruleset(ioc_config):
+  """Parses the IOC indicated by `ioc_config` into a RuleSet instance.
+  
+  Args:
+    ioc_config: dict{'name', 'url', 'format'}
+  """
+  format = ioc_config['format']
+  if format not in _PARSERS:
+    raise ValueError('Unrecognized IOC feed format |{format}|')
+  
+  parser = _PARSERS[format](ioc_config)
+  return parser.Parse(_fetch_contents(ioc_config['url']), ioc_config['name'])
+
+
+def _fetch_contents(fullurl):
+  """Fetch the data contents (encoded as utf-8) for the resource found at `url`.
+  
+  Args:
+    fullurl: string to URL where the IOC feed data is found.
+  """
+  with urllib.request.urlopen()

--- a/rids/network_capture.py
+++ b/rids/network_capture.py
@@ -14,74 +14,112 @@
 
 
 import ipaddress
-import logging
+import subprocess
 
 
-allowed_sni_port = set([
-    ('mtalk.google.com', 5228),
-    ('proxy-safebrowsing.googleapis.com', 80),
-    ('courier.push.apple.com', 5223),
-    ('imap.gmail.com', 993),
-])
+class RemoteServerScanner:
+  """Continuously scans the network traffic for remote IPs being contacted.
+  The scan() function is an iterator that produces a dict{...} representing
+  the endpoints (specifically the `remote_ip` and `remote_port` fields).  This
+  scanning will continue until the pipe from the underlying network scanning
+  process is closed.
+  """
+  def __init__(self, host_ip):
+    self._proc = _start_tshark([
+        '-f', 'ip and src ip == {host_ip}',
+        '-Tfields',
+        # The order of the following fields determines the ordering in output
+        '-e', 'frame.time',
+        '-e', 'ip.dst',
+        '-l',
+    ])
+
+  def scan(self):
+    """Generator for observations of remote IP addresses."""
+    for line in iter(self._proc.stdout.readline, b''):
+      values = line.split('\t')
+      observation = {
+        'timestamp': values[0],
+        'remote_ip': values[1],
+      }
+      yield observation
 
 
-# TODO: decouple detection and logging
+class HandshakeScanner:
+  """Continuously scans the network traffic for TLS handshakes.
+  The scan() function is an iterator that produces a tuple of
+    (client_hello, server_hello)
+  where server_hello may be `None` if only the client hello has been seen, and
+  will include both when the server_hello is found.  Each is a dict that has
+  `remote_ip`, `remote_port`, `sni` (if present), `ja3`, `ja3s` as properties.
+  """
+  def __init__(self, host_ip):
+    self._proc = _start_tshark([
+        '-f', 'tcp and not (src port 443 or dst port 443)',
+        '-Y', (f'(tls.handshake.type == 1 and ip.src == {host_ip})' +
+              f'or (tls.handshake.type == 2 and ip.dst == {host_ip})'),
+        '-Tfields',
+        # Ordering of the following fields determines the ordering in output,
+        # except that missing fields are skipped.
+        '-e', 'frame.time',
+        '-e', 'tcp.stream',
+        '-e', 'tls.handshake.type',
+        '-e', 'ip.src',
+        '-e', 'tcp.srcport',
+        '-e', 'ip.dst',
+        '-e', 'tcp.dstport',
+        '-e', 'tls.handshake.extensions_server_name',
+        '-e', 'tls.handshake.ja3',
+        '-e', 'tls.handshake.ja3_full',
+        '-e', 'tls.handshake.ja3s',
+        '-e', 'tls.handshake.ja3s_full',
+        '-l',
+    ])
+    self._tls_streams = {}
 
-def detect_tls_events(input_stream):
-    unusual_tls_traffic = {}  # map[int]dict stream_id -> connection_details
+  # Ignore these false positives.
+  # TODO: include these in handshake-related rules instead of filtering here?
+  _allowed_sni_port = set([
+      ('mtalk.google.com', 5228),
+      ('proxy-safebrowsing.googleapis.com', 80),
+      ('courier.push.apple.com', 5223),
+      ('imap.gmail.com', 993),
+  ])
 
-    logging.basicConfig(level=logging.DEBUG,
-                        format='%(asctime)s %(levelname)-8s %(message)s',
-                        datefmt='%m-%d %H:%M',
-                        filename='/var/maldetector.log',
-                        filemode='a')
+  def scan(self):
+    """Generator for observations of unusual TLS traffic."""
+    for line in iter(self._proc.stdout.readline, b''):
+      values = line.split('\t')
+      observation = {
+        'timestamp': values[0],
+      }
+      stream_id = int(values[1])
+      if int(values[2]) == 1:  # client hello
+        sni_and_port = (values[7], int(values[6]))
+        if sni_and_port in self._allowed_sni_port:
+          continue
 
-    for line in iter(input_stream, b''):
-        values = line.split('\t')
-        if len(values) >= 8:
-            stream_id = int(values[1])
-            if int(values[2]) == 1:  # client hello
-                sni_and_port = (values[7], int(values[6]))
-                if sni_and_port not in allowed_sni_port:
-                    unusual_tls_traffic[stream_id] = {
-                        'client_ts': values[0],
-                        'server_ip': values[5],
-                        'server_port': values[6],
-                        'server_name': values[7],
-                        'ja3': values[8],
-                        'ja3_full': values[9],
-                    }
-            elif int(values[2]) == 2:  # server hello
-                port = int(values[4])
-                if port == 443:
-                    continue
-                connection_details = unusual_tls_traffic.get(stream_id, None)
-                if not connection_details:
-                    continue
-                connection_details['ja3s'] = values[8]
-                connection_details['ja3s_full'] = values[9]
-                logging.info('connection_details %s', connection_details)
-                del unusual_tls_traffic[stream_id]
+        observation['remote_ip'] = ipaddress.ip_address(values[5])
+        observation['remote_port'] = int(values[6])
+        observation['server_name'] = values[7]
+        observation['ja3'] = values[8]
+        observation['ja3_full'] = values[9]
+        self._tls_streams[stream_id] = observation
 
-            print(line.rstrip())
+      elif int(values[2]) == 2:  # server hello
+        observation = self._tls_streams.get(stream_id, None)
+        if not observation:
+          continue
+        observation['ja3s'] = values[8]
+        observation['ja3s_full'] = values[9]
+        yield observation
+        del self._tls_streams[stream_id]
 
 
-def warn_about_ip_address(ip_address, bad_ips):
-  ip_address = str(ip_address)
-  if ip_address in bad_ips:
-    ioc_sources = bad_ips[ip_address]
-    logging.info('CONNECTING WITH BAD IP %s (found in %s)',
-                 ip_address, ioc_sources)
-    return True
-  return False
- 
-
-def detect_bad_ips(dataline, bad_ips):
-  if not dataline:
-    return False
-  values = dataline.split('\t')
-  ip_from, ip_to = ipaddress.ip_address(values[1]), ipaddress.ip_address(values[2])
-  if (warn_about_ip_address(ip_from, bad_ips)
-      or warn_about_ip_address(ip_to, bad_ips)):
-    return True
-  return False
+def _start_tshark(args):
+  process = subprocess.Popen(
+      ['tshark'] + args,
+      stdout=subprocess.PIPE,
+      stderr=subprocess.PIPE,
+      universal_newlines=True)
+  return process

--- a/rids/rids.py
+++ b/rids/rids.py
@@ -15,112 +15,110 @@
 # limitations under the License.
 
 
+
 """
 Main entry point for RIDS, a Remote Intrusion Detection System.
 """
 
-
 import ipaddress
 import json
-import os
-import subprocess
-import sys
-import urllib.request
+import logging
+import threading
+import urllib
+import queue
 
 from absl import app
 from absl import flags
 
+from rids import config
 from rids import network_capture
+from rids.iocs import iocs
+from rids import rules
 
 FLAGS = flags.FLAGS
 flags.DEFINE_string('host_ip', None,
                     'The IP of the host process, for ignoring direct requests')
-flags.DEFINE_string('config_path', 'config.json',
-                    'Path where IOC configuration can be found; uses config.json by default')
-
-
-def retrieve_bad_ips():
-  bad_ips = {}
-  with open(FLAGS.config_path, 'r') as f:
-    config = json.load(f)
-    for source in config['ioc_sources']:
-      # Download a fresh version of each IOC source in the config.
-      with urllib.request.urlopen(source['url']) as ioc_data:
-        # TODO check format of ioc source, branch to different parsers
-        # For now, the only source format is newline-seprated bad IPv4 addresses
-        # TODO perform parsing in a separate function from config handling
-        for line in ioc_data.readlines():
-          line = line.strip().decode('utf-8')
-          if not line: continue
-          bad_ip = str(ipaddress.ip_address(line))
-          if bad_ip not in bad_ips:
-            bad_ips[bad_ip] = [source['name']]
-          else:
-            bad_ips[bad_ip].append(source['name'])
-  return bad_ips
-
-
-def get_external_ip():
-  with urllib.request.urlopen('https://ipinfo.io/ip') as my_ip:
-    return my_ip.read().decode("utf-8").strip()
+flags.DEFINE_string('config_path', '/etc/rids/config.json',
+                    'file path indicating where IOC configuration can be found')
+flags.DEFINE_string('eventlog_path', '/var/rids/events.log',
+                    'file path indicating where to append new event logs')
 
 
 def main(argv):
+  """Main entry point of the app.  Also bound to CLI `rids` by setuptools."""
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
 
+  logging.basicConfig(level=logging.DEBUG,
+                      format='%(asctime)s %(levelname)-8s %(message)s',
+                      datefmt='%m-%d %H:%M',
+                      filename=FLAGS.eventlog_path,
+                      filemode='a')
+
+  cfg = config.ParseFile(FLAGS.config_path)
+  ruleset = rules.RuleSet()
+  for ioc_config in cfg['iocs']:
+    ruleset.MergeRuleset(iocs.parse_ruleset(ioc_config))
+
+  host_ip = _get_host_ip()
+  print(f'Using {host_ip} as host IP address')
+
+  event_queue = queue.Queue()
+  threading.Thread(
+      target=_inspect_tls_traffic,
+      args=(host_ip, ruleset, event_queue))
+  threading.Thread(
+      target=_inspect_remote_endpoints,
+      args=(host_ip, ruleset, event_queue))
+
+  while True:
+    # We just log the suspicious events for now, but here is where we could
+    # do post-processing and/or share sightings of known / unknown threats.
+    event = event_queue.get()
+    logging.log(json.puts(event))
+    event_queue.task_done()
+
+
+def _inspect_tls_traffic(host_ip, ruleset, q):
+  """Worker function for thread that inspects client and server hellos.
+  
+  Args:
+    ruleset: a RuleSet object to perform evaluation with
+    q: a Queue for relaying events back to the main thread
+  """
+  tls_capture = network_capture.HandshakeScanner(host_ip)
+  for observation in tls_capture.scan():
+    events = ruleset.ProcessHandshake(observation)
+    for event in events:
+      q.put(event)
+
+
+def _inspect_remote_endpoints(host_ip, ruleset, q):
+  """Worker function for thread that inspects remote IP addresses.
+
+  Args:
+    ruleset: a RuleSet object to perform evaluation with
+    q: a Queue for relaying events back to the main thread
+  """
+  remote_ip_capture = network_capture.RemoteServerSanner(host_ip)
+  for observation in remote_ip_capture.scan():
+    events = ruleset.ProcessEndpoint(observation)
+    for event in events:
+      q.put(event)
+
+
+def _get_host_ip():
+  """Retrieves the host IP address from its flag, else from a remote site.
+  
+  Returns:
+    ipaddress of the host running RIDS
+  """
   host_ip = FLAGS.host_ip
   if not FLAGS.host_ip:
-    host_ip = get_external_ip()
+    with urllib.request.urlopen('https://ipinfo.io/ip') as my_ip:
+      host_ip = my_ip.read().decode("utf-8").strip()
   host_ip = ipaddress.ip_address(host_ip)
-  print('Using', host_ip, 'as host IP address')
-
-  # Spawn tshark and read its output.  This assumes the wireshark-dev/stable
-  # version of tshark has been installed.
-  oddtls_capture = subprocess.Popen([
-      'tshark',
-      '-f', 'tcp and not (src port 443 or dst port 443)',
-      '-Y', (f'(tls.handshake.type == 1 and ip.src == {host_ip})' +
-             f'or (tls.handshake.type == 2 and ip.dst == {host_ip})'),
-      '-Tfields',
-      # The order of the following fields determines the ordering in output
-      '-e', 'frame.time',
-      '-e', 'tcp.stream',
-      '-e', 'tls.handshake.type',
-      '-e', 'ip.src',
-      '-e', 'tcp.srcport',
-      '-e', 'ip.dst',
-      '-e', 'tcp.dstport',
-      '-e', 'tls.handshake.extensions_server_name',
-      '-e', 'tls.handshake.ja3',
-      '-e', 'tls.handshake.ja3_full',
-      '-e', 'tls.handshake.ja3s',
-      '-e', 'tls.handshake.ja3s_full',
-      '-l',
-      ],
-      stdout=subprocess.PIPE,
-      stderr=subprocess.PIPE,
-      universal_newlines=True)
-  network_capture.detect_tls_events(oddtls_capture.stdout.readline)
-
-  bad_ips = retrieve_bad_ips()
-  ip_capture = subprocess.Popen([
-      'tshark',
-      '-Tfields',
-      # The order of the following fields determines the ordering in output
-      '-e', 'frame.time',
-      '-e', 'ip.src',
-      '-e', 'ip.dst',
-      '-l',
-      ],
-      stdout=subprocess.PIPE,
-      stderr=subprocess.PIPE,
-      universal_newlines=True)
-
-  # TODO define a class in packet_filter instead of using a function
-  # filter = network_capture.Filter(); filter.add_bad_ips(bad_ips); ...
-  for line in iter(ip_capture.stdout.readline, b''):
-    network_capture.detect_bad_ips(line, bad_ips)
+  return host_ip
 
 
 if __name__ == '__main__':

--- a/rids/rules.py
+++ b/rids/rules.py
@@ -1,0 +1,100 @@
+# Copyright 2022 Jigsaw Operations LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Generalizes the various formats of IOCs into a common class, RuleSet.
+RuleSet is a value type that represents evaluation on packets and connections.
+It can be constructed from one of the flavors of parsers in `rids.iocs` or
+merged from combining a pair of RuleSet instances.  Its constructor takes a
+dict (or equivalent) argument that mirrors the tree-like structure of its
+combined rules, for ease of creating new IOC decoders and when testing.
+Evaluation of the RuleSet is done with the process_connection(...) and
+process_packet(...) which take appropriate context objects and produce a
+list of zero or more Event instances from matching rules in the RuleSet.
+"""
+
+
+import collections
+
+
+class RuleSet:
+    __slots__ = ('ip_address_rules', )
+
+    def __init__(self):
+      self.ip_address_rules = collections.defaultdict(list)
+
+    def MergeRuleset(self, other):
+      """Simple implementation of a merging of rule sets."""
+      for key, valuel in other.ip_address_rules:
+        self.ip_address_rules[key].extend(value)
+
+    def AddRule(self, rule):
+      """Simple implementation of adding a single rule to this rule set."""
+      if hasattr(rule, 'matches_ip'):
+        self.ip_address_rules[str(rule.matches_ip)].append(rule)
+
+    def ProcessHandshake(self, observation):
+      """Process a handshake-related observation."""
+      return Event(observation)
+
+    def ProcessEndpoint(self, observation):
+      """Process observations related to a remote IP address."""
+      ip_str = str(observation['remote_ip'])
+      if ip_str in self.ip_address_rules:
+        events = []
+        for rule in self.ip_address_rules[ip_str]:
+          event = {}
+          event.update(observation)
+          event.update(rule.as_dict())
+          events.append(event)
+        return events
+      return None
+
+
+class Rule:
+  """Represents a single rule that accommodates a variety of IOC rule types."""
+  __slots__ = ('msg', 'source', 'fetched', 'matches_ip')
+  # TODO: include source rule properties like 'reference', 'header', 'options'
+
+  def __init__(self, **properties):
+    for key, value in properties.items():
+      setattr(self, key, value)
+
+  def __str__(self):
+    output = [
+        f'{self.msg}',
+        f'Found in [{self.source}] last fetched at {self.fetched}',
+    ]
+    
+    if hasattr(self, 'reference'):
+      output.append(self.reference)
+    return '\n'.join(output)
+
+  def as_dict(self):
+    """Returns full definition of the rule as a string."""
+    return {
+        key: getattr(self, key)
+    for key in self.__slots__}
+
+
+class Event:
+  """Generalization of an Event sighting, i.e. suspicious activity or threat."""
+
+  def __init__(self, properties):
+    # The event properties have a very loose definition at this moment.
+    # TODO stabilize the schema, perhaps based on MISP or Dovecot event types.
+    self.properties = properties
+
+  def __str__(self):
+    return str(self.properties)


### PR DESCRIPTION
New abstractions added for IOC feed parsing, rule definition (and evaluation) and the Event instances that are produced from evaluating rules.

I left RuleSet and Rule as partially defined, to keep things simple for now. Event is basically schemaless as well, but the IOC feed parsing and how it produces RuleSet instances is more well defined.  All of these are likely to grow and evolve in upcoming commits and merges but this is a good place to start.  It matches the features of the existing code and actually fixes a couple of bugs.  Existing tests are refactored, more tests will be added soon.