### PR TITLE
use `pip3 install ...rids@main` in the install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,31 +16,20 @@
 
 # Install script for RIDS, the Remote Intrusion Detection System.
 
-# install script
-add-apt-repository --assume-yes ppa:wireshark-dev/stable
+# use the dev/stable version of tshark to get ja3/ja3s signatures
+add-apt-repository ppa:wireshark-dev/stable
 apt --assume-yes update
+
+# install system dependencies
 apt --assume-yes install tshark python3-pip
 
-# download repo with scripts
-git clone https://github.com/Jigsaw-Code/rids
-pushd rids
+# install RIDS from repo, including its python dependencies
+pip3 install git+git://github.com/Jigsaw-Code/rids.git@main
 
-pip3 install absl-py
-
-# copy wrapper script into a bin/ path
-cp detect.sh /usr/local/sbin
-chmod +x /usr/local/sbin/detect.sh
-cp rids/network_capture.py /usr/local/sbin
-cp rids/rids.py /usr/local/sbin
-
-# Define sysctl .service config to /etc/systemd and start service
-
-# first, stop the service if it exists and is running
+# this may be an upgrade, stop the service if it exists and is running
 systemctl stop rids.service >& /dev/null
 
+# Define sysctl .service config for /etc/systemd and start service
 cp rids.service /etc/systemd/system/
 systemctl daemon-reload
 systemctl enable rids.service --now
-
-# return to previous directory
-popd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rids"
-version = "0.1.0"
+version = "0.2.0"
 description = "Remote Intrusion Detection System"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,11 @@ dependencies = [
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tools.setuptools]
+[tool.setuptools]
 packages = ["rids"]
+
+[tool.setuptools.package-data]
+"*" = ["*.service", "*.json"]
 
 [project.scripts]
 rids = "rids.rids:main"

--- a/rids.service
+++ b/rids.service
@@ -2,9 +2,9 @@
 Description=Remote Intrusion Detection System daemon
 
 [Service]
-User=root
+User=rids
 WorkingDirectory=/usr/local/sbin
-ExecStart="/usr/local/sbin/rids.py --eventlog_path=/var/rids/events.log --config_path=/etc/rids/config.json"
+ExecStart="python3 -m rids --eventlog_path=/var/rids/events.log --config_path=/etc/rids/config.json"
 Restart=always
 
 [Install]

--- a/rids/iocs.py
+++ b/rids/iocs.py
@@ -17,7 +17,7 @@
 
 import collections
 from dataclasses import dataclass
-from types import Set
+from typing import Set
 
 from rids.ioc_formats import allowed_sni_port
 from rids.ioc_formats import bad_ip_list


### PR DESCRIPTION
This makes the RIDS binary install much cleaner than individually copying the .py code into somewhere in $PATH.

Also increments version to reflect the IOC format updates and src-refactor and fixes up the pyproject.toml setuptools-specific config